### PR TITLE
Version/1.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker:18.03.0-ce
+FROM docker:18.06.2-ce 
 
-LABEL maintainer "mats116 <mats.kazuki@gmail.com>"
+LABEL maintainer "im-tech <tech@intimatemerger.com>"
 
 RUN apk add --no-cache \
         git \
@@ -15,5 +15,5 @@ RUN apk add --no-cache \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
     rm -rf ./awscli-bundle && \
     # ecs-cli
-    curl -o /usr/bin/ecs-cli https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-v1.4.2 && \
+    curl -o /usr/bin/ecs-cli https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-v1.12.1 && \
     chmod +x /usr/bin/ecs-cli

--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ Dockerfile for [ecs-cli](https://github.com/aws/amazon-ecs-cli)
 
 Supported tags and respective Dockerfile links
 
+- 1.12.1 (for testing) 
 - 1.0.0, latest
 - 0.6.2


### PR DESCRIPTION
scoreでのビルドで利用しようとしたら、メンテされてなかったので新しくしときました。
latestイメージはratのビルドで利用してるので、ひとまずドラフトで置いときます。
（マージするとそっちに影響でるのでしばらくscoreのビルドで使って問題ないか様子見しゃす）